### PR TITLE
feat: add emacs keymap mode

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -25,5 +25,16 @@ pub fn set_global_render_config(config: RenderConfig) {
 /// Default page size when displaying options to the user.
 pub const DEFAULT_PAGE_SIZE: usize = 7;
 
-/// Default value of vim mode.
-pub const DEFAULT_VIM_MODE: bool = false;
+#[derive(Debug, Clone, Copy, PartialEq)]
+/// Specifies the keymap mode to use when navigating prompts.
+pub enum KeymapMode {
+    /// No keybindings are enabled
+    None,
+    /// Vim keybindings (hjkl) are enabled
+    Vim,
+    /// Emacs keybindings (C-p, C-n, C-f, C-b) are enabled
+    Emacs,
+}
+
+/// Default value of keymap mode.
+pub const DEFAULT_KEYMAP_MODE: KeymapMode = KeymapMode::None;

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -12,6 +12,7 @@ mod password;
 mod select;
 mod text;
 
+pub use crate::config::KeymapMode;
 pub use confirm::Confirm;
 pub use custom_type::CustomType;
 #[cfg(feature = "date")]


### PR DESCRIPTION
This PR adds a functionality to enable emacs keybindings for navigating the inquire prompts. As it doesn't make sense to enable multiple keybindings at once I extracted it into an enum (which is a breaking change).