### PR TITLE
support submit-on-valid-parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
+### Features
+
+- The `CustomType` and `Confirm` prompts now support auto-submitting on valid input. [#321](https://github.com/mikaelmello/inquire/pull/321).
+
+### Dependencies
+
 - Bumped MSRV from 1.80 -> 1.82 due to new requirements of dependencies.
 
 ## [0.9.1] - 2025-09-16

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -67,6 +67,10 @@ name = "confirm"
 path = "confirm.rs"
 
 [[example]]
+name = "confirm_on_input"
+path = "confirm_on_input.rs"
+
+[[example]]
 name = "custom_type"
 path = "custom_type.rs"
 

--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -35,6 +35,7 @@ fn main() {
             true => String::from("sim"),
             false => String::from("não"),
         },
+        confirm_on_input: false,
         render_config: RenderConfig::default(),
     }
     .prompt()

--- a/examples/confirm_on_input.rs
+++ b/examples/confirm_on_input.rs
@@ -1,0 +1,28 @@
+use inquire::Confirm;
+
+fn main() {
+    println!("Standard confirm prompt (requires Enter after y/n):");
+    let standard = Confirm::new("Do you want to continue?")
+        .with_default(true)
+        .prompt();
+
+    match standard {
+        Ok(true) => println!("You chose to continue!\n"),
+        Ok(false) => println!("You chose not to continue!\n"),
+        Err(_) => println!("Error occurred!\n"),
+    }
+
+    println!("Confirm with immediate input (y/n submits immediately):");
+    let immediate = Confirm::new("Are you sure you want to delete this file?")
+        .with_default(false)
+        .with_confirm_on_input(true)
+        .prompt();
+
+    match immediate {
+        Ok(true) => println!("File will be deleted!"),
+        Ok(false) => println!("File deletion cancelled."),
+        Err(_) => println!("Error occurred!"),
+    }
+
+    println!("\nTip: In the second prompt, just press 'y' or 'n' - no Enter needed!");
+}

--- a/inquire-derive/Cargo.toml
+++ b/inquire-derive/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Mikael Mello <git@mikaelmello.com>"]
 keywords = ["cli", "ask", "prompt", "question", "interactive"]
 categories = ["command-line-interface", "value-formatting"]
 include = ["/src", "/../LICENSE"]
-rust-version = "1.80.0"
+rust-version = "1.82.0"
 
 [lib]
 proc-macro = true

--- a/inquire/Cargo.toml
+++ b/inquire/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Mikael Mello <git@mikaelmello.com>"]
 keywords = ["cli", "ask", "prompt", "question", "interactive"]
 categories = ["command-line-interface", "value-formatting"]
 include = ["/src", "/../LICENSE"]
-rust-version = "1.80.0"
+rust-version = "1.82.0"
 
 [lib]
 name = "inquire"
@@ -52,4 +52,3 @@ unicode-width = "0.2"
 [dev-dependencies]
 rstest = "0.26.1"
 chrono = { version = "0.4" }
-

--- a/inquire/src/prompts/confirm/mod.rs
+++ b/inquire/src/prompts/confirm/mod.rs
@@ -91,6 +91,9 @@ pub struct Confirm<'a> {
     /// Error message displayed when a value could not be parsed from input.
     pub error_message: String,
 
+    /// Whether to confirm immediately when 'y' or 'n' is typed, without requiring Enter.
+    pub confirm_on_input: bool,
+
     /// RenderConfig to apply to the rendered interface.
     ///
     /// Note: The default render config considers if the NO_COLOR environment variable
@@ -132,6 +135,7 @@ impl<'a> Confirm<'a> {
             parser: Self::DEFAULT_PARSER,
             default_value_formatter: Self::DEFAULT_DEFAULT_VALUE_FORMATTER,
             error_message: String::from(Self::DEFAULT_ERROR_MESSAGE),
+            confirm_on_input: false,
             render_config: get_configuration(),
         }
     }
@@ -201,6 +205,12 @@ impl<'a> Confirm<'a> {
         self
     }
 
+    /// Sets whether to confirm immediately when 'y' or 'n' is typed, without requiring Enter.
+    pub fn with_confirm_on_input(mut self, confirm_on_input: bool) -> Self {
+        self.confirm_on_input = confirm_on_input;
+        self
+    }
+
     /// Parses the provided behavioral and rendering options and prompts
     /// the CLI user for input according to the defined rules.
     ///
@@ -254,6 +264,7 @@ impl<'a> From<Confirm<'a>> for CustomType<'a, bool> {
             validators: vec![],
             error_message: co.error_message,
             render_config: co.render_config,
+            submit_on_valid_parse: co.confirm_on_input,
         }
     }
 }

--- a/inquire/src/prompts/custom_type/mod.rs
+++ b/inquire/src/prompts/custom_type/mod.rs
@@ -54,6 +54,7 @@ use self::prompt::CustomTypePrompt;
 ///         Ok(val) => Ok(val),
 ///         Err(_) => Err(()),
 ///     },
+///     submit_on_valid_parse: false,
 ///     render_config: RenderConfig::default(),
 /// };
 /// ```
@@ -126,6 +127,10 @@ pub struct CustomType<'a, T> {
     /// config is treated as the only source of truth. If you want to customize colors
     /// and still support NO_COLOR, you will have to do this on your end.
     pub render_config: RenderConfig<'a>,
+
+    /// If true, submits immediately when parser successfully parses input
+    /// Useful for single-character selection prompts
+    pub submit_on_valid_parse: bool,
 }
 
 impl<'a, T> CustomType<'a, T>
@@ -152,6 +157,7 @@ where
             validators: Self::DEFAULT_VALIDATORS,
             error_message: "Invalid input".into(),
             render_config: get_configuration(),
+            submit_on_valid_parse: false,
         }
     }
 
@@ -251,6 +257,16 @@ where
     /// and still support NO_COLOR, you will have to do this on your end.
     pub fn with_render_config(mut self, render_config: RenderConfig<'a>) -> Self {
         self.render_config = render_config;
+        self
+    }
+
+    /// Enables automatic submission when input is successfully parsed.
+    ///
+    /// When enabled, the prompt will submit immediately after each keystroke
+    /// that results in successful parsing and validation, without requiring
+    /// Enter.
+    pub fn with_submit_on_valid_parse(mut self, enabled: bool) -> Self {
+        self.submit_on_valid_parse = enabled;
         self
     }
 

--- a/inquire/src/prompts/custom_type/prompt.rs
+++ b/inquire/src/prompts/custom_type/prompt.rs
@@ -23,6 +23,7 @@ pub struct CustomTypePrompt<'a, T> {
     validators: Vec<Box<dyn CustomTypeValidator<T>>>,
     parser: CustomTypeParser<'a, T>,
     error_message: String,
+    submit_on_valid_parse: bool,
 }
 
 impl<'a, T> From<CustomType<'a, T>> for CustomTypePrompt<'a, T>
@@ -49,6 +50,7 @@ where
             parser: co.parser,
             input,
             error_message: co.error_message,
+            submit_on_valid_parse: co.submit_on_valid_parse,
         }
     }
 }
@@ -127,6 +129,16 @@ where
                 self.input.handle(input_action).into()
             }
         };
+
+        // Check if we should auto-submit after this input change
+        if self.submit_on_valid_parse {
+            // Try to parse and validate the current input
+            if let Ok(answer) = self.get_final_answer() {
+                if matches!(self.validate_current_answer(&answer)?, Validation::Valid) {
+                    return Ok(ActionResult::Submit);
+                }
+            }
+        }
 
         Ok(result)
     }


### PR DESCRIPTION
This allows `CustomType` prompts to auto-submit when the input is valid. Specifically, this makes it possible to have prompts similar to Git's:

```
$ git add -p
... <snip> ...

(1/2) Stage this hunk [y,n,q,a,d,j,J,g,/,e,p,?]? ?
y - stage this hunk
n - do not stage this hunk
q - quit; do not stage this hunk or any of the remaining ones
a - stage this hunk and all later hunks in the file
d - do not stage this hunk or any of the later hunks in the file
j - leave this hunk undecided, see next undecided hunk
J - leave this hunk undecided, see next hunk
g - select a hunk to go to
/ - search for a hunk matching the given regex
e - manually edit the current hunk
p - print the current hunk, 'P' to use the pager
? - print help
(1/2) Stage this hunk [y,n,q,a,d,j,J,g,/,e,p,?]? q
```

Which don't require the `return` key to be pressed when a valid option is provided.