### PR TITLE
Bump MSRV to 1.82 due to dep requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  MSRV: 1.80.0
+  MSRV: 1.82.0
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [Unreleased] <!-- ReleaseDate -->
 
-- No changes since the latest release below.
+- Bumped MSRV from 1.80 -> 1.82 due to new requirements of dependencies.
 
 ## [0.9.1] - 2025-09-16
 


### PR DESCRIPTION
Without this, builds will fail 

```
error: rustc 1.80.0 is not supported by the following packages:
  derive_more@2.1.1 requires rustc 1.81.0
  derive_more-impl@2.1.1 requires rustc 1.81.0
  indexmap@2.12.1 requires rustc 1.82
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.80.0
```

example: https://github.com/mikaelmello/inquire/actions/runs/20666926694/job/59341003795?pr=326